### PR TITLE
Bumped @nexes/mongo-knex to version 0.1.1

### DIFF
--- a/lib/nql.js
+++ b/lib/nql.js
@@ -33,7 +33,7 @@ module.exports = (queryString, options) => {
     };
 
     // Use MongoKnex to apply the query to a query builder object
-    api.querySQL = qb => mongoKnex(qb, api.parse());
+    api.querySQL = qb => mongoKnex(qb, api.parse(), options);
 
     // Get back the original query string
     api.toString = () => queryString;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "sinon": "6.0.0"
   },
   "dependencies": {
-    "@nexes/mongo-knex": "0.0.1",
+    "@nexes/mongo-knex": "0.1.1",
     "@nexes/nql-lang": "0.0.1",
     "mingo": "2.2.2"
   }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -74,9 +74,6 @@ describe('Public API', function () {
 
         query.queryJSON({tags: [{slug: 'video'}, {slug: 'audio'}]}).should.be.false();
         query.queryJSON({id: 3, tags: [{slug: 'video'}, {slug: 'photo'}, {slug: 'audio'}]}).should.be.true();
-
-        // @TODO implement actual joins in mongo-knex!
-        query.querySQL(knex('posts')).toQuery().should.eql('select * from `posts` where `tags`.`slug` in (\'photo\')');
     });
 });
 

--- a/test/nql_knex.test.js
+++ b/test/nql_knex.test.js
@@ -242,24 +242,4 @@ describe('Integration with Knex', function () {
             });
         });
     });
-
-    describe('Aliases', function () {
-        it('can handle empty aliases', function () {
-            const query = makeQuery('tags:[photo]', {aliases: {}});
-
-            query.toQuery().should.eql('select * from `posts` where `posts`.`tags` in (\'photo\')');
-        });
-
-        it('can expand a field alias', function () {
-            const query = makeQuery('tags:[photo]', {aliases: {tags: 'tags.slug'}});
-
-            query.toQuery().should.eql('select * from `posts` where `tags`.`slug` in (\'photo\')');
-        });
-
-        it('can expand multiple field aliases', function () {
-            const query = makeQuery('tags:[photo]+authors:joanne', {aliases: {tags: 'tags.slug', authors: 'authors.slug'}});
-
-            query.toQuery().should.eql('select * from `posts` where (`tags`.`slug` in (\'photo\') and `authors`.`slug` = \'joanne\')');
-        });
-    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,11 @@
 # yarn lockfile v1
 
 
-"@nexes/mongo-knex@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@nexes/mongo-knex/-/mongo-knex-0.0.1.tgz#141c8ca380e95c1460fe2abcd777d7fd2bb14e8f"
+"@nexes/mongo-knex@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@nexes/mongo-knex/-/mongo-knex-0.1.1.tgz#ef2d184f225126b160c84e9659e52d5b83b7cbc4"
   dependencies:
+    debug "^4.1.0"
     lodash "^4.17.10"
 
 "@nexes/nql-lang@0.0.1":
@@ -334,6 +335,12 @@ debug@^2.2.0, debug@^2.3.3:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
+
+debug@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  dependencies:
+    ms "^2.1.1"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -1158,6 +1165,10 @@ mocha@5.2.0:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
 mute-stream@0.0.7:
   version "0.0.7"


### PR DESCRIPTION
refs #1

- mongo-knex supports some relation cases already
- forward options to mongo-knex
- remove tests which have a wrong assertions
  - these tests are removed in https://github.com/NexesJS/NQL/pull/5 anyway